### PR TITLE
Add issue and bug templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,32 @@
+---
+name: Report a bug 🌪️
+description: Submit a bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Description
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Describe the bug
+      description: A clear description of what the bug is.
+  - type: textarea
+    validations:
+      required: false
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Steps to reproduce the problem.
+      placeholder: |
+        For example:
+        1. Install this version of the application
+        2. Run command '...'
+        3. See error
+  - type: textarea
+    validations:
+      required: false
+    attributes:
+      label: Describe the solution
+      description: If you know the solution, describe it.

--- a/.github/ISSUE_TEMPLATE/idea.yaml
+++ b/.github/ISSUE_TEMPLATE/idea.yaml
@@ -1,0 +1,15 @@
+---
+name: New idea 💡!
+description: Submit a new idea!
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Description
+        Describe your idea including all the requirements
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Describe the idea
+      description: A clear description of what the idea is, including if possible a diagram explaining it.

--- a/.github/ISSUE_TEMPLATE/idea.yaml
+++ b/.github/ISSUE_TEMPLATE/idea.yaml
@@ -13,3 +13,9 @@ body:
     attributes:
       label: Describe the idea
       description: A clear description of what the idea is, including if possible a diagram explaining it.
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Technologies involved/required
+      description: Technologies involved in the creation of this idea


### PR DESCRIPTION
I added two templates that we can use to create issues in our project. One for new ideas, and another one for bugs.
Once we publish this repository, we can use these templates in ALL the repositories inside the team.
If we want to create more global documentation, we can publish it in this repository as Github describes in this URL: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

 
Feel free to request any change, everything is welcome!